### PR TITLE
Fixed result when mutlple item has same hash

### DIFF
--- a/tests/test_ignore_order.py
+++ b/tests/test_ignore_order.py
@@ -198,7 +198,6 @@ class TestIgnoreOrder:
         }
         assert result2 == ddiff2
 
-    @pytest.mark.skip
     def test_list_difference_ignore_order_report_repetition3(self):
         t1 = [{"id": 1}, {"id": 1}, {"id": 1}]
         t2 = [{"id": 1, "name": 1}]


### PR DESCRIPTION
Status: test_list_difference_ignore_order_report_repetition3 is passing
All other 891 test cases are also passing.
It solved issue 344. It was due to multiple item were same. So, hash will be same but iteration was different. i.e 3 items were in t1 out of those 3 only one was modified in t2, but other 2 were removed. But due to single hash, current logic was updating it for all.

Related to test_list_difference_ignore_order_report_repetition2
In that mentioned result will come if below flags are set there 
```
cutoff_intersection_for_pairs=0, cutoff_distance_for_pairs=0
```
So, Are you expecting same result for below too? 
```
cutoff_intersection_for_pairs=1, cutoff_distance_for_pairs=1
```